### PR TITLE
fix: remove unused problematic variable new_tr

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ def formatContributors(repo, columnRow, width, font,
         if name == None:
             name = htmlURL[19:]
         if USER >= columnRow:
-            new_tr, HEAD, USER = '', HEAD + new_tr, 0
+            USER = 0
         HEAD += f'''<td align="center"><a href={htmlURL}><img src={avatarURL} width="{width};" alt={name}/><br /><sub style="font-size:{font}px"><b>{name}</b></sub></a></td>'''
         USER += 1
     return HEAD + TAIL
@@ -36,7 +36,7 @@ def writeRepo(repo, contributorList, htmlStart, htmlEnd, path, commitMessage, CO
         if end[0] != contributorList:
             end[0] = contributorList
             text = text_str[0] + CONTRIB + end[0] + end[1]
-            repo.update_file(contents.path, commitMessage, text, contents.sha)
+            # repo.update_file(contents.path, commitMessage, text, contents.sha)
         else:
             pass
     except IndexError:

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ def writeRepo(repo, contributorList, htmlStart, htmlEnd, path, commitMessage, CO
         if end[0] != contributorList:
             end[0] = contributorList
             text = text_str[0] + CONTRIB + end[0] + end[1]
-            # repo.update_file(contents.path, commitMessage, text, contents.sha)
+            repo.update_file(contents.path, commitMessage, text, contents.sha)
         else:
             pass
     except IndexError:


### PR DESCRIPTION
`new_tr` was not used and the statement made the CI fail with
```
Traceback (most recent call last):
  File "/main.py", line 61, in <module>
    writeRepo(repo, formatContributors(repo, COLUMN_PER_ROW, IMG_WIDTH,
  File "/main.py", line 19, in formatContributors
    new_tr, HEAD, USER = '', HEAD + new_tr, 0
UnboundLocalError: local variable 'new_tr' referenced before assignment
```

@vinckr