### PR TITLE
Fix useless trailing slashes and missing quotes around attributes values

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def formatContributors(repo, columnRow, width, font,
             name = htmlURL[19:]
         if USER >= columnRow:
             USER = 0
-        HEAD += f'''<td align="center"><a href={htmlURL}><img src={avatarURL} width="{width};" alt={name}/><br /><sub style="font-size:{font}px"><b>{name}</b></sub></a></td>'''
+        HEAD += f'''<td align="center"><a href="{htmlURL}"><img src="{avatarURL}" width="{width}" alt="{name}"/><br /><sub style="font-size:{font}px"><b>{name}</b></sub></a></td>'''
         USER += 1
     return HEAD + TAIL
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def formatContributors(repo, columnRow, width, font,
             name = htmlURL[19:]
         if USER >= columnRow:
             USER = 0
-        HEAD += f'''<td align="center"><a href="{htmlURL}"><img src="{avatarURL}" width="{width}" alt="{name}"/><br /><sub style="font-size:{font}px"><b>{name}</b></sub></a></td>'''
+        HEAD += f'''<td align="center"><a href="{htmlURL}"><img src="{avatarURL}" width="{width}" alt="{name}"/><br><sub style="font-size:{font}px"><b>{name}</b></sub></a></td>'''
         USER += 1
     return HEAD + TAIL
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def formatContributors(repo, columnRow, width, font,
             name = htmlURL[19:]
         if USER >= columnRow:
             USER = 0
-        HEAD += f'''<td align="center"><a href="{htmlURL}"><img src="{avatarURL}" width="{width}" alt="{name}"/><br><sub style="font-size:{font}px"><b>{name}</b></sub></a></td>'''
+        HEAD += f'''<td align="center"><a href="{htmlURL}"><img src="{avatarURL}" width="{width}" alt="{name}"><br><sub style="font-size:{font}px"><b>{name}</b></sub></a></td>'''
         USER += 1
     return HEAD + TAIL
 


### PR DESCRIPTION
As discussed in #7, I found out attributes values does not have sourrounding quotes and void elements does have useless trailing slashes.

I applied needed changes, it is not a breaking changes (in a matter of fact, it fixes a **potential breaking** bug for some HTML parsers).